### PR TITLE
feat: 공통 에러 처리 코드 작성

### DIFF
--- a/src/main/java/com/skeleton/common/exception/CustomException.java
+++ b/src/main/java/com/skeleton/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.skeleton.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/skeleton/common/exception/ErrorCode.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.skeleton.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 예시)
+    // RECRUITMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "R001", "해당하는 채용공고가 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/skeleton/common/exception/ErrorResponse.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorResponse.java
@@ -1,0 +1,47 @@
+package com.skeleton.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private String errorCode;
+    private String errorMessage;
+
+    public static ErrorResponse of(String errorCode, String errorMessage) {
+        return ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    public static ErrorResponse of(String errorCode, BindingResult bindingResult) {
+        return ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(createErrorMessage(bindingResult))
+                .build();
+    }
+
+    private static String createErrorMessage(BindingResult bindingResult) {
+        StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        for(FieldError fieldError : fieldErrors) {
+            if(!isFirst) {
+                sb.append(", ");
+            } else {
+                isFirst = false;
+            }
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("] ");
+            sb.append(fieldError.getDefaultMessage());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/skeleton/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/skeleton/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.skeleton.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // javax.validation.Valid binding error 가 발생하는 경우
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getBindingResult());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // @RequestParam 이 enum 으로 binding 되지 못한 경우
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // 지원하지 않는 HTTP method 를 호출하는 경우
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    // 비즈니스 로직 실행 도중 예외 발생하는 경우
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    // 그 외 예외가 발생하는 경우
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

공통 예외 처리를 위한 코드를 작성했습니다.
`ErrorCode` Enum 클래스를 도입하여 애플리케이션 내에서 발생할 수 있는 에러들을 효과적으로 관리합니다.

### 사용 예시
```java
// ErrorCode.java
USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U001", "해당하는 사용자가 없습니다.")
```
예시의 `"U001"`는 서비스의 고유한 에러 코드를 나타내며, `도메인 앞글자 + 숫자` 형식을 따릅니다.

정의한 에러 코드는 서비스 클래스에서 다음과 같이 사용할 수 있습니다:

```java
// UserService.java
public User findUser(Long userId) {
        return userRepository.findById(userId)
                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
    }
```
## 📋 변경 사항

- [x] 새로운 기능 추가

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

Issue #9

 