### PR TITLE
feat: 게시물 좋아요 API 구현

### DIFF
--- a/src/main/java/com/skeleton/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/skeleton/common/config/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.skeleton.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.Charset;
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .setConnectTimeout(Duration.ofMillis(5000)) // connection-timeout
+                .setReadTimeout(Duration.ofMillis(5000)) // read-timeout
+                .additionalMessageConverters(new StringHttpMessageConverter(Charset.forName("UTF-8")))
+                .build();
+    }
+}

--- a/src/main/java/com/skeleton/common/exception/ErrorCode.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 예시)
     // RECRUITMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "R001", "해당하는 채용공고가 없습니다."),
-    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "P001", "해당하는 게시물이 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "해당하는 게시물이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/skeleton/common/exception/ErrorCode.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 예시)
     // RECRUITMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "R001", "해당하는 채용공고가 없습니다."),
+    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "P001", "해당하는 게시물이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -2,12 +2,17 @@ package com.skeleton.feed.controller;
 
 import com.skeleton.feed.service.PostService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/feedmoa")
 public class PostController {
     private final PostService postService;
+
+    @PatchMapping("/likes/{id}")
+    private ResponseEntity<?> addLike(@PathVariable Long id) {
+        return ResponseEntity.ok().body(postService.addLike(id));
+    }
 }

--- a/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
@@ -1,0 +1,18 @@
+package com.skeleton.feed.dto;
+
+import com.skeleton.feed.entity.Post;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+public class AddLikeResponse {
+
+    Long id;
+    private int likeCount;
+
+    public AddLikeResponse(Post post) {
+        this.id = post.getId();
+        this.likeCount = post.getLikeCount();
+    }
+}

--- a/src/main/java/com/skeleton/feed/entity/Post.java
+++ b/src/main/java/com/skeleton/feed/entity/Post.java
@@ -41,4 +41,9 @@ public class Post extends BaseTimeEntity {
     private int likeCount = 0;
 
     private int shareCount = 0;
+    
+    // == 비즈니스 로직 == //
+    public void addlike(){
+        this.likeCount +=1;
+    }
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -20,7 +20,7 @@ public class PostService {
     public AddLikeResponse addLike(Long id) {
         Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
-        //restTemplateService.clickLikeOnSns(post.getContentId(), post.getType());
+        //snsApiCallerService.clickLikeOnSns(post.getContentId(), post.getType());
         post.addlike();
         return new AddLikeResponse(post);
     }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -1,11 +1,33 @@
 package com.skeleton.feed.service;
 
+import com.skeleton.feed.dto.AddLikeResponse;
+import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+
+    private final RestTemplateService restTemplateService;
+
+    @Transactional
+    public AddLikeResponse addLike(Long id) {
+        Optional<Post> o = postRepository.findById(id);
+        if (o.isPresent()) {
+            Post post = o.get();
+            //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 동작하는 API URL이 아니므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
+            //restTemplateService.clickLikeOnSns(post.getContentId(), post.getType());
+            post.addlike();
+            return new AddLikeResponse(post);
+        } else {
+            throw new EntityNotFoundException("게시물을 찾을 수 없습니다. ID: " + id);
+        }
+    }
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -1,33 +1,27 @@
 package com.skeleton.feed.service;
 
+import com.skeleton.common.exception.CustomException;
+import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
 
-    private final RestTemplateService restTemplateService;
+    private final SnsApiCallerService snsApiCallerService;
 
     @Transactional
     public AddLikeResponse addLike(Long id) {
-        Optional<Post> o = postRepository.findById(id);
-        if (o.isPresent()) {
-            Post post = o.get();
-            //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 동작하는 API URL이 아니므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
-            //restTemplateService.clickLikeOnSns(post.getContentId(), post.getType());
-            post.addlike();
-            return new AddLikeResponse(post);
-        } else {
-            throw new EntityNotFoundException("게시물을 찾을 수 없습니다. ID: " + id);
-        }
+        Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
+        //restTemplateService.clickLikeOnSns(post.getContentId(), post.getType());
+        post.addlike();
+        return new AddLikeResponse(post);
     }
 }

--- a/src/main/java/com/skeleton/feed/service/RestTemplateService.java
+++ b/src/main/java/com/skeleton/feed/service/RestTemplateService.java
@@ -1,0 +1,56 @@
+package com.skeleton.feed.service;
+
+import com.skeleton.feed.enums.SnsType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RestTemplateService {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    //기능 개발을 위한 요소로, Endpoint에 저장된 URL은 실제 동작하는 API URL이 아님
+    public ResponseEntity<String> clickLikeOnSns(String contentId, SnsType snsType) {
+        String url = Endpoint.getUrl(snsType) + contentId;
+        RequestEntity<String> requestEntity = RequestEntity.post(url).body(null);
+        return restTemplate.exchange(requestEntity, String.class); //post
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    enum Endpoint {
+        FACEBOOK(SnsType.FACEBOOK, "https://www.facebook.com/likes/"),
+        TWITTER(SnsType.INSTAGRAM, "https://www.twitter.com/likes/"),
+        INSTAGRAM(SnsType.INSTAGRAM, "https://www.instagram.com/likes/"),
+        THREADS(SnsType.THREADS, "https://www.threads.net/likes/");
+        SnsType snsType;
+        String url;
+
+        public static String getUrl(SnsType snsType) {
+            Optional<Endpoint> endpoint = Arrays.stream(values()).filter(value -> value.snsType.equals(snsType))
+                    .findAny();
+            if (endpoint.isPresent())
+                return endpoint.get().url;
+            else
+                return null;
+        }
+
+    }
+
+}

--- a/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
+++ b/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class RestTemplateService {
+public class SnsApiCallerService {
 
     @Autowired
     private RestTemplate restTemplate;

--- a/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
+++ b/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
@@ -28,7 +28,18 @@ public class SnsApiCallerService {
     public ResponseEntity<String> clickLikeOnSns(String contentId, SnsType snsType) {
         String url = Endpoint.getUrl(snsType) + contentId;
         RequestEntity<String> requestEntity = RequestEntity.post(url).body(null);
-        return restTemplate.exchange(requestEntity, String.class); //post
+        ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
+        
+        // TODO : 각 SNS API 응답 타입을 고려하여 수정
+        if (response.getStatusCode() == HttpStatus.OK) {
+            return response;
+        }
+        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+            throw new CustomException(ErrorCode.SNS_POST_NOT_FOUND);
+        }
+
+        return response;
+        
     }
 
 

--- a/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
+++ b/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
@@ -36,7 +36,7 @@ public class SnsApiCallerService {
     @AllArgsConstructor
     enum Endpoint {
         FACEBOOK(SnsType.FACEBOOK, "https://www.facebook.com/likes/"),
-        TWITTER(SnsType.INSTAGRAM, "https://www.twitter.com/likes/"),
+        TWITTER(SnsType.TWITTER, "https://www.twitter.com/likes/"),
         INSTAGRAM(SnsType.INSTAGRAM, "https://www.instagram.com/likes/"),
         THREADS(SnsType.THREADS, "https://www.threads.net/likes/");
         SnsType snsType;

--- a/src/test/java/com/skeleton/feed/PostDummyMaker.java
+++ b/src/test/java/com/skeleton/feed/PostDummyMaker.java
@@ -1,0 +1,81 @@
+package com.skeleton.feed;
+
+import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.enums.SnsType;
+import com.skeleton.feed.repository.PostRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.lang.reflect.Constructor;
+import java.util.Random;
+import java.util.UUID;
+
+@Disabled //DB에 더미데이터 넣을때만 주석 처리해서 사용
+@SpringBootTest
+public class PostDummyMaker {
+    @Autowired
+    private PostRepository postRepository;
+
+    static SnsType[] snsTypes;
+    static Random random;
+    static BufferedReader br;
+
+    // Post 10개 분량으로 설정된 문자열
+    static String s = """
+            국회나 그 위원회의
+            대한민국은 국제평화의 유지에 노력하고 침략적 전쟁을 부인한다.
+            중앙선거관리위원회는
+            대법원장과 대법관이 아닌 법관의 임기는 10년으로 하며, 법률이 정하는 바에 의하여 연임할 수 있다.
+            대통령의 국법상 행위
+            국회는 국무총리 또는 국무위원의 해임을 대통령에게 건의할 수 있다.
+            언론·출판은 타인의
+            나는 헌법을 준수하고 국가를 보위하며 조국의 평화적 통일과 국민의 자유와 복리의 증진 및 민족문화의 창달에 노력하여 대통령으로서의 직책을 성실히 수행할 것을 국민 앞에 엄숙히 선서합니다.
+            국무총리 또는 행정각
+            국정감사 및 조사에 관한 절차 기타 필요한 사항은 법률로 정한다.
+            형사피의자 또는 형사
+            광물 기타 중요한 지하자원·수산자원·수력과 경제상 이용할 수 있는 자연력은 법률이 정하는 바에 의하여 일정한 기간 그 채취·개발 또는 이용을 특허할 수 있다.
+            비상계엄이 선포된 때
+            국회에 제출된 법률안 기타의 의안은 회기중에 의결되지 못한 이유로 폐기되지 아니한다. 다만, 국회의원의 임기가 만료된 때에는 그러하지 아니하다.
+            언론·출판에 대한 허
+            정부는 예산에 변경을 가할 필요가 있을 때에는 추가경정예산안을 편성하여 국회에 제출할 수 있다.
+            대통령의 임기는 5년
+            농업생산성의 제고와 농지의 합리적인 이용을 위하거나 불가피한 사정으로 발생하는 농지의 임대차와 위탁경영은 법률이 정하는 바에 의하여 인정된다.
+            모든 국민은 통신의
+            모든 국민은 신체의 자유를 가진다. 누구든지 법률에 의하지 아니하고는 체포·구속·압수·수색 또는 심문을 받지 아니하며, 법률과 적법한 절차에 의하지 아니하고는 처벌·보안처분 또는 강제노역을 받지 아니한다.""";
+
+
+    @BeforeAll
+    static void init() {
+        snsTypes = SnsType.values();
+        random = new Random();
+        br = new BufferedReader(new StringReader(s));
+
+    }
+
+
+    @DisplayName("Post 더미데이터 10개 생성, 해시태그 X")
+    @RepeatedTest(10)
+    void addDummy() throws Exception {
+
+        // 생성자 접근제어자 변경
+        Constructor<?>[] constructor = Post.class.getDeclaredConstructors();
+        constructor[0].setAccessible(true);
+        Post post = (Post) constructor[0].newInstance();
+
+        //필드값 주입
+        ReflectionTestUtils.setField(post, "contentId", UUID.randomUUID().toString());
+        ReflectionTestUtils.setField(post, "title", br.readLine());
+        ReflectionTestUtils.setField(post, "content", br.readLine());
+        ReflectionTestUtils.setField(post, "type", snsTypes[random.nextInt(snsTypes.length)]); // SnsType 랜덤
+
+        postRepository.save(post);
+
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 게시물 목록 또는 상세 에서 게시물 좋아요 클릭 시 사용되는 API를 구현하였습니다.
- 요구사항에 따라 외부 SNS의 좋아요 클릭하는 API를 구현하였지만 제시된 URL이 유효하지 않으므로 일단 구현하되,  주석처리 해두었습니다. 
- 기능 동작 확인을 위해  테스트코드 쪽에 더미데이터 생성기를 만들었습니다. 테스트 실행 시 더미데이터가 DB에 저장됩니다 


## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷



## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#2

## 🙌 리뷰 및 피드백
