### PR TITLE
feat: 게시물 공유 API 구현

### DIFF
--- a/src/main/java/com/skeleton/common/exception/ErrorCode.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
     // RECRUITMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "R001", "해당하는 채용공고가 없습니다."),
   
     //User
-    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "R001", "이미 계정이 존재합니다.")
+    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "R001", "이미 계정이 존재합니다."),
 
     //Post
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "해당하는 게시물이 없습니다."),

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -15,4 +15,9 @@ public class PostController {
     private ResponseEntity<?> addLike(@PathVariable Long id) {
         return ResponseEntity.ok().body(postService.addLike(id));
     }
+
+    @PatchMapping("/{id}/share")
+    private ResponseEntity<?> addShare(@PathVariable Long id) {
+        return ResponseEntity.ok().body(postService.addShare(id));
+    }
 }

--- a/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
@@ -2,7 +2,6 @@ package com.skeleton.feed.dto;
 
 import com.skeleton.feed.entity.Post;
 import lombok.Getter;
-import lombok.Setter;
 
 
 @Getter

--- a/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/AddLikeResponse.java
@@ -8,8 +8,8 @@ import lombok.Setter;
 @Getter
 public class AddLikeResponse {
 
-    Long id;
-    private int likeCount;
+    private final Long id;
+    private final int likeCount;
 
     public AddLikeResponse(Post post) {
         this.id = post.getId();

--- a/src/main/java/com/skeleton/feed/dto/AddShareResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/AddShareResponse.java
@@ -1,0 +1,16 @@
+package com.skeleton.feed.dto;
+
+import com.skeleton.feed.entity.Post;
+import lombok.Getter;
+
+
+@Getter
+public class AddShareResponse {
+
+    private final Long id;
+    private final int shareCount;
+    public AddShareResponse(Post post) {
+        this.id = post.getId();
+        this.shareCount = post.getShareCount();
+    }
+}

--- a/src/main/java/com/skeleton/feed/entity/Post.java
+++ b/src/main/java/com/skeleton/feed/entity/Post.java
@@ -46,4 +46,8 @@ public class Post extends BaseTimeEntity {
     public void addlike(){
         this.likeCount +=1;
     }
+
+    public void addShare() {
+        this.shareCount +=1;
+    }
 }

--- a/src/main/java/com/skeleton/feed/entity/Post.java
+++ b/src/main/java/com/skeleton/feed/entity/Post.java
@@ -43,7 +43,7 @@ public class Post extends BaseTimeEntity {
     private int shareCount = 0;
     
     // == 비즈니스 로직 == //
-    public void addlike(){
+    public void addLike(){
         this.likeCount +=1;
     }
 

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -3,6 +3,7 @@ package com.skeleton.feed.service;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
+import com.skeleton.feed.dto.AddShareResponse;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,14 @@ public class PostService {
         //snsApiCallerService.clickLikeOnSns(post.getContentId(), post.getType());
         post.addlike();
         return new AddLikeResponse(post);
+    }
+
+    @Transactional
+    public AddShareResponse addShare(Long id) {
+        Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
+        //snsApiCallerService.clickShareOnSns(post.getContentId(), post.getType());
+        post.addShare();
+        return new AddShareResponse(post);
     }
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -22,7 +22,7 @@ public class PostService {
         Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
         //snsApiCallerService.clickLikeOnSns(post.getContentId(), post.getType());
-        post.addlike();
+        post.addLike();
         return new AddLikeResponse(post);
     }
 

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -15,12 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
     private final PostRepository postRepository;
 
-    private final SnsApiCallerService snsApiCallerService;
+    // 외부 SNS API 호출 서비스, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로, 현재 호출시 오류시 오류 발생
+    // private final SnsApiCallerService snsApiCallerService;
 
     @Transactional
     public AddLikeResponse addLike(Long id) {
         Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
         //snsApiCallerService.clickLikeOnSns(post.getContentId(), post.getType());
         post.addLike();
         return new AddLikeResponse(post);
@@ -29,7 +29,6 @@ public class PostService {
     @Transactional
     public AddShareResponse addShare(Long id) {
         Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        //외부 SNS API 호출로직, 요구 사항이라서 구현하였으나 실제 유효한 API URL을 사용하지 않으므로 주석 처리해둠. 필요시 주석 해제하고 사용할 것.
         //snsApiCallerService.clickShareOnSns(post.getContentId(), post.getType());
         post.addShare();
         return new AddShareResponse(post);

--- a/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
+++ b/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
@@ -37,7 +37,7 @@ public class SnsApiCallerService {
     }
 
     public ResponseEntity<String> clickLikeOnSns(String contentId, SnsType snsType) {
-        String url = Endpoint.getUrl(snsType) + contentId;
+        String url = LikesEndpoint.getUrl(snsType) + contentId;
         RequestEntity<String> requestEntity = RequestEntity.post(url).body(null);
         ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
         validateResponseFromSns(response);
@@ -55,11 +55,9 @@ public class SnsApiCallerService {
     }
 
 
-
-
     @Getter
     @AllArgsConstructor
-    enum Endpoint {
+    enum LikesEndpoint {
         FACEBOOK(SnsType.FACEBOOK, "https://www.facebook.com/likes/"),
         TWITTER(SnsType.TWITTER, "https://www.twitter.com/likes/"),
         INSTAGRAM(SnsType.INSTAGRAM, "https://www.instagram.com/likes/"),
@@ -68,7 +66,7 @@ public class SnsApiCallerService {
         String url;
 
         public static String getUrl(SnsType snsType) {
-            Optional<Endpoint> endpoint = Arrays.stream(values()).filter(value -> value.snsType.equals(snsType))
+            Optional<LikesEndpoint> endpoint = Arrays.stream(values()).filter(value -> value.snsType.equals(snsType))
                     .findAny();
             if (endpoint.isPresent())
                 return endpoint.get().url;

--- a/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
+++ b/src/main/java/com/skeleton/feed/service/SnsApiCallerService.java
@@ -29,20 +29,18 @@ public class SnsApiCallerService {
     @Autowired
     private RestTemplate restTemplate;
 
-    //기능 개발을 위한 요소로, Endpoint에 저장된 URL은 실제 동작하는 API URL이 아님
+    private static void validateResponseFromSns(ResponseEntity<String> response) {
+        // TODO : 각 SNS API 응답 타입을 고려하여 예외 수정
+        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+            throw new CustomException(ErrorCode.SNS_POST_NOT_FOUND);
+        }
+    }
+
     public ResponseEntity<String> clickLikeOnSns(String contentId, SnsType snsType) {
         String url = Endpoint.getUrl(snsType) + contentId;
         RequestEntity<String> requestEntity = RequestEntity.post(url).body(null);
         ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
-
-        // TODO : 각 SNS API 응답 타입을 고려하여 수정
-        if (response.getStatusCode() == HttpStatus.OK) {
-            return response;
-        }
-        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-            throw new CustomException(ErrorCode.SNS_POST_NOT_FOUND);
-        }
-
+        validateResponseFromSns(response);
         return response;
     }
 
@@ -51,12 +49,7 @@ public class SnsApiCallerService {
         log.info(url);
         RequestEntity<String> requestEntity = RequestEntity.post(url).body(null);
         ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
-        if (response.getStatusCode() == HttpStatus.OK) {
-            return response;
-        }
-        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-            throw new CustomException(ErrorCode.SNS_POST_NOT_FOUND);
-        }
+        validateResponseFromSns(response);
         log.info(response.toString().substring(0,20));
         return response;
     }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 게시물 목록 또는 상세 에서 `공유하기` 클릭 시 사용되는 API를 구현하였습니다. (`PATCH` "/api/posts/{id}/share")
- 요구사항에 따라 외부 SNS의 공유하기를 클릭하는 API를 구현하였습니다.
- #2 관련 코드 중 일부를 리펙토링하였습니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

## 📌 체크리스트

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#2 #16

## 🙌 리뷰 및 피드백
