### PR TITLE
feat: 로그인 api 및 jwt 인증 / 인가 구현

### DIFF
--- a/src/main/java/com/skeleton/auth/config/JwtAuthenticationProvider.java
+++ b/src/main/java/com/skeleton/auth/config/JwtAuthenticationProvider.java
@@ -1,0 +1,58 @@
+package com.skeleton.auth.config;
+
+import com.skeleton.common.exception.CustomException;
+import com.skeleton.common.exception.ErrorCode;
+import com.skeleton.user.crypto.PasswordEncoder;
+import com.skeleton.user.entity.User;
+import com.skeleton.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    // TODO: 유저 repository 구현이 끝나면 수정
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+        String account = authentication.getPrincipal().toString();
+        String password = authentication.getCredentials().toString();
+
+        // TODO : 유저 레포지토리에서 받아와서 유저의 이름과 패스어드 검증
+        // 유저 계정이 없을 시 로그인 실패 에러
+        User user = userRepository.findByAccount(account).orElseThrow(
+                () -> new UsernameNotFoundException("Invalid account.")
+        );
+        // 비밀번호 비교
+        if (passwordEncoder.matches(password, user.getPassword())) {
+            return new UsernamePasswordAuthenticationToken(
+                    account, password, authentication.getAuthorities()
+            );
+        } else {
+            // 비밀번호 틀림
+            throw new BadCredentialsException("Invalid password.") {
+            };
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/skeleton/auth/config/SecurityConfig.java
+++ b/src/main/java/com/skeleton/auth/config/SecurityConfig.java
@@ -1,22 +1,45 @@
 package com.skeleton.auth.config;
 
+import com.skeleton.auth.filter.JwtAuthenticationFilter;
+import com.skeleton.auth.filter.JwtAuthorizationFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    private JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    @Lazy
+    @Autowired
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          JwtAuthorizationFilter jwtAuthorizationFilter){
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.jwtAuthorizationFilter = jwtAuthorizationFilter;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // 회원가입 말고는 모두 인증/인가가 필요하다.
         http.authorizeHttpRequests(request -> request
-                .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/signup").permitAll()
+                .anyRequest().authenticated()
         );
 
         http.csrf(CsrfConfigurer::disable);
@@ -27,5 +50,10 @@ public class SecurityConfig {
         );
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception{
+        return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/skeleton/auth/controller/AuthController.java
+++ b/src/main/java/com/skeleton/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.skeleton.auth.controller;
+
+import com.skeleton.auth.enums.TokenType;
+import com.skeleton.auth.jwt.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+    private final JwtUtils jwtUtils;
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(Authentication authentication) {
+        return ResponseEntity.ok().body(jwtUtils.generateToken(authentication, TokenType.REFRESH));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<String> refresh(Authentication authentication) {
+        return ResponseEntity.ok().body(jwtUtils.generateToken(authentication, TokenType.ACCESS));
+    }
+}

--- a/src/main/java/com/skeleton/auth/enums/TokenType.java
+++ b/src/main/java/com/skeleton/auth/enums/TokenType.java
@@ -1,0 +1,16 @@
+package com.skeleton.auth.enums;
+
+public enum TokenType {
+    REFRESH(60 * 60 * 24 * 1000),
+    ACCESS(60 * 60 * 1000);
+
+    private final long expirationTime;
+
+    TokenType(long expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    public long getExpirationTime() {
+        return expirationTime;
+    }
+}

--- a/src/main/java/com/skeleton/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/skeleton/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package com.skeleton.auth.filter;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skeleton.common.exception.CustomException;
+import com.skeleton.common.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+    private final AuthenticationManager authenticationManager;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            Map<String, String> jsonMap = objectMapper.readValue(request.getReader(), Map.class);
+
+            String account = jsonMap.get("account");
+            String password = jsonMap.get("password");
+
+            if (account != null && password != null) {
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(account, password);
+                authenticationToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+                try {
+                    Authentication authentication = authenticationManager.authenticate(
+                            authenticationToken
+                    );
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    filterChain.doFilter(request, response);
+                } catch (AuthenticationException e) {
+                    // 계정 또는 패스워드가 틀림
+                    SecurityContextHolder.clearContext();
+                    handlerExceptionResolver.resolveException(request, response, null, new CustomException(ErrorCode.LOGIN_FAILED));
+                }
+            } else {
+                // 계정, 패스워드 미입력시 에러
+                SecurityContextHolder.clearContext();
+                handlerExceptionResolver.resolveException(request, response, null, new CustomException(ErrorCode.LOGIN_DATA_IS_NULL));
+            }
+        } catch (JacksonException e) {
+            // JsonParseException, MismatchedInputException 통합 처리
+            log.error("JacksonException", e);
+            handlerExceptionResolver.resolveException(request, response, null, new CustomException(ErrorCode.JSON_PARSE_ERROR));
+        } catch (ClassCastException e) {
+            // 스트링 타입에 정수형등 잘못된 타입을 넣었을때
+            log.error("ClassCastException", e);
+            handlerExceptionResolver.resolveException(request, response, null, new CustomException(ErrorCode.MISS_MATCH_INPUT));
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        /**
+         * login 은 계정과 패스워드를 입력하여 refresh 토큰을 받아야함
+         */
+        return !request.getServletPath().equals("/api/login");
+    }
+}

--- a/src/main/java/com/skeleton/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/skeleton/auth/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,93 @@
+package com.skeleton.auth.filter;
+
+import com.skeleton.auth.enums.TokenType;
+import com.skeleton.auth.jwt.JwtUtils;
+import com.skeleton.common.exception.CustomException;
+import com.skeleton.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String token = request.getHeader("Authorization");
+
+            // 헤더가 없을 시
+            if (token == null) {
+                handlerExceptionResolver.resolveException(
+                        request, response, null, new CustomException(ErrorCode.NEED_AUTHORIZATION_HEADER)
+                );
+                return;
+            }
+
+            // 토큰 타입마다 키가 달라 구분하기 위함.
+            // refresh 토큰은 /api/refresh 에만 사용 가능하다.
+            TokenType tokenType;
+            if (request.getRequestURI().equals("/api/refresh")) {
+                tokenType = TokenType.REFRESH;
+            } else {
+                tokenType = TokenType.ACCESS;
+            }
+
+            if (jwtUtils.validateAccessToken(token, tokenType)) {
+                Claims claims = jwtUtils.parseClaim(token, tokenType);
+
+                String account = claims.getSubject();
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(
+                                account,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        );
+                authenticationToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                filterChain.doFilter(request, response);
+            }
+        } catch (JwtException e) {
+            // 만료, 형식 등 여러 에러가 있지만 하나로 통합하였습니다. - JWT 검증 에러
+            handlerExceptionResolver.resolveException(
+                    request, response, null, new CustomException(ErrorCode.INVALID_JWT)
+            );
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        /**
+         * token 이 필요한 url
+         * 필요
+         * refresh - access 토큰을 받기 위해 refresh 토큰이 필요하다.
+         * 이후 모든 API 요청 Header 에 JWT 가 항시 포함되며, JWT 유효성을 검증합니다. <- 요구사항
+         *
+         * 필요 x
+         * login - 로그인은 계정, 패스워드를 입력하여 refresh 토큰을 받는다.
+         * signup - 회원가입은 토큰이 필요없다.
+         */
+        return (!request.getServletPath().equals("/api/refresh") && !request.getServletPath().startsWith("/api/posts/"));
+    }
+}

--- a/src/main/java/com/skeleton/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/skeleton/auth/jwt/JwtUtils.java
@@ -1,0 +1,67 @@
+package com.skeleton.auth.jwt;
+
+import com.skeleton.auth.enums.TokenType;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JwtUtils.class);
+
+    // 키는 환경변수로 설정
+    @Value("${jwt.access.secret}")
+    private String ACCESS_SECRET_KEY;
+    @Value("${jwt.refresh.secret")
+    private String REFRESH_SECRET_KEY;
+    private Map<String, String> secretKeys = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        secretKeys.put("ACCESS", ACCESS_SECRET_KEY);
+        secretKeys.put("REFRESH", REFRESH_SECRET_KEY);
+    }
+
+    // 토큰 검증
+    public boolean validateAccessToken(String token, TokenType tokenType) {
+        Jwts.parser().setSigningKey(secretKeys.get(tokenType.name()))
+                .parseClaimsJws(getAccessToken(token));
+        return true;
+    }
+
+    // TODO: 후에 권한 추가시 Authorities 추가
+    public String generateToken(
+            Authentication authentication,
+            TokenType tokenType) {
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("tokenType", tokenType.name())
+                .setIssuer("quantum-jump")
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + tokenType.getExpirationTime()))
+                .signWith(SignatureAlgorithm.HS512, secretKeys.get(tokenType.name()))
+                .compact();
+    }
+
+    public Claims parseClaim(String token, TokenType tokenType) {
+        return Jwts.parser()
+                .setSigningKey(secretKeys.get(tokenType.name()))
+                .parseClaimsJws(getAccessToken(token))
+                .getBody();
+    }
+
+    // 헤더에 Bearer {JWT} 가 들어감
+    private String getAccessToken(String token) {
+        return token.split(" ")[1].trim();
+    }
+}

--- a/src/main/java/com/skeleton/common/exception/ErrorCode.java
+++ b/src/main/java/com/skeleton/common/exception/ErrorCode.java
@@ -14,6 +14,14 @@ public enum ErrorCode {
     //Post
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "해당하는 게시물이 없습니다."),
     SNS_POST_NOT_FOUND(HttpStatus.NOT_FOUND,"P002" ,"해당하는 SNS 게시글이 없습니다."),
+
+    //Auth
+    LOGIN_DATA_IS_NULL(HttpStatus.BAD_REQUEST,"A001","계정과 패스워드 값을 입력해야 합니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED,"A002","계정 또는 패스워드가 틀렸습니다."),
+    JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST,"A003","Json 파싱 에러."),
+    MISS_MATCH_INPUT(HttpStatus.BAD_REQUEST,"A004","잘못된 데이터 타입 입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED,"A005","잘못된 토큰 입니다."),
+    NEED_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST,"A006","Authorization 헤더가 필요합니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

### API

사용자는 다음 API 를 통해 토큰을 생성 합니다.

```/api/login POST``` : Refresh 토큰 생성, Json 입력 필요
```json
{
    "account":"user",
    "password":"asdasd111!"
}
```

```/api/refresh POST``` : Access 토큰 생성, 헤더에 토큰 필요

요구사항 : ```이후 모든 API 요청 Header 에 JWT 가 항시 포함되며, JWT 유효성을 검증합니다.```
위의 요구사항에 맞게 ```/api/signup``` 을 제외한 모든  API 요청은 로그인을 통해 Refresh 토큰을 생성 후 Refresh 토큰을 사용하여 Access 토큰을 받아야합니다. 헤더에 다음 형식의 JWT가 들어가야 합니다.
```
{키} : {Bearer + JWT키}
Authorization : Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyIiwidG9rZW5UeXBlIjoiUkVGUkVTSCIsImlzcyI6InF1YW50dW0tanVtcCIsImlhdCI6MTY5ODQ2MzAwMywiZXhwIjoxNjk4NTQ5NDAzfQ.2b6k34v2NdcXF38enbMnr5jTnBj2hQpEs3EbiHts9NqhZxXNZ-sBp4kLgLgsS3I0Iyjx5tmTEz_NPFwCzQmGZw
```

### 에러 처리
```/api/login```
- 계정 또는 패스워드 틀림
- 계정 또는 패스워드 미입력
- Json 파싱 에러
- 문자 타입의 json에 정수형을 넣었을 때

```/api/refresh```
- 만료, 형식, 잘못된 토큰 등 여러 에러가 있지만 하나로 통합했습니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈
Issue #10 

## 🙌 리뷰 및 피드백

이후 ```/api/posts/*``` 가 아닌 다른 url 사용시 코드 수정이 필요하니 연락바랍니다.
