### PR TITLE
feat: 게시물 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/skeleton/common/config/WebConfig.java
+++ b/src/main/java/com/skeleton/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.skeleton.common.config;
+
+import com.skeleton.common.util.EnumConverterFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        ConverterFactory converterFactory = new EnumConverterFactory();
+        registry.addConverterFactory(converterFactory);
+    }
+}

--- a/src/main/java/com/skeleton/common/util/EnumConverterFactory.java
+++ b/src/main/java/com/skeleton/common/util/EnumConverterFactory.java
@@ -1,0 +1,39 @@
+package com.skeleton.common.util;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class EnumConverterFactory implements ConverterFactory<String, Enum<? extends EnumMapperType>> {
+    @Override
+    public <T extends Enum<? extends EnumMapperType>> Converter<String, T> getConverter(Class<T> targetType) {
+        if (EnumMapperType.class.isAssignableFrom(targetType)) {
+            return new StringToEnumConverter<>(targetType);
+        }
+        return null;
+    }
+
+    private static class StringToEnumConverter<T extends Enum<? extends EnumMapperType>> implements Converter<String, T> {
+        private final Map<String, T> map;
+
+        StringToEnumConverter(Class<T> enumType) {
+            T[] enumConstants = enumType.getEnumConstants();
+            map = Arrays.stream(enumConstants)
+                    .collect(Collectors.toMap(
+                            enumConstant -> ((EnumMapperType) enumConstant).getValue(),
+                            Function.identity()
+                    ));
+        }
+
+        @Override
+        public T convert(String source) {
+            return map.get(source);
+        }
+    }
+}

--- a/src/main/java/com/skeleton/common/util/EnumMapperType.java
+++ b/src/main/java/com/skeleton/common/util/EnumMapperType.java
@@ -1,0 +1,5 @@
+package com.skeleton.common.util;
+
+public interface EnumMapperType {
+    String getValue();
+}

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -3,10 +3,10 @@ package com.skeleton.feed.controller;
 import com.skeleton.feed.dto.PostQueryRequest;
 import com.skeleton.feed.dto.PostResponse;
 import com.skeleton.feed.service.PostService;
-import com.skeleton.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,8 +16,8 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public ResponseEntity<Page<PostResponse>> getPostsByQuery(@ModelAttribute PostQueryRequest request, User user) {
-        return ResponseEntity.ok().body(postService.getPostsByQuery(request, user));
+    public ResponseEntity<Page<PostResponse>> getPostsByQuery(@ModelAttribute PostQueryRequest request, Authentication authentication) {
+        return ResponseEntity.ok().body(postService.getPostsByQuery(request, authentication));
     }
 
     @PatchMapping("/{id}/likes")

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -3,6 +3,7 @@ package com.skeleton.feed.controller;
 import com.skeleton.feed.dto.PostQueryRequest;
 import com.skeleton.feed.dto.PostResponse;
 import com.skeleton.feed.service.PostService;
+import com.skeleton.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,7 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public ResponseEntity<Page<PostResponse>> getPostsByQuery(@ModelAttribute PostQueryRequest request, User User) {
+    public ResponseEntity<Page<PostResponse>> getPostsByQuery(@ModelAttribute PostQueryRequest request, User user) {
         return ResponseEntity.ok().body(postService.getPostsByQuery(request, user));
     }
 

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -1,7 +1,12 @@
 package com.skeleton.feed.controller;
 
+import com.skeleton.feed.dto.PostQueryRequest;
+import com.skeleton.feed.dto.PostResponse;
 import com.skeleton.feed.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class PostController {
     private final PostService postService;
+
+    @RequestMapping("/posts")
+    public ResponseEntity<Page<PostResponse>> getPostsByQuery(@ModelAttribute PostQueryRequest request, User User) {
+        return ResponseEntity.ok(postService.getPostsByQuery(request, user));
+    }
 }

--- a/src/main/java/com/skeleton/feed/dto/PostQueryRequest.java
+++ b/src/main/java/com/skeleton/feed/dto/PostQueryRequest.java
@@ -1,0 +1,27 @@
+package com.skeleton.feed.dto;
+
+import com.skeleton.feed.enums.Order;
+import com.skeleton.feed.enums.OrderBy;
+import com.skeleton.feed.enums.SearchBy;
+import com.skeleton.feed.enums.SnsType;
+import lombok.Getter;
+
+@Getter
+public class PostQueryRequest {
+    private String hashtag;
+
+    private SnsType type;
+
+    private OrderBy orderBy = OrderBy.CREATED_AT;
+
+    private Order order = Order.DESC;
+
+    private SearchBy searchBy = SearchBy.TITLE_CONTENT;
+
+    private String search;
+
+    private int pageCount = 10;
+
+    private int page = 0;
+}
+

--- a/src/main/java/com/skeleton/feed/dto/PostQueryRequest.java
+++ b/src/main/java/com/skeleton/feed/dto/PostQueryRequest.java
@@ -1,12 +1,14 @@
 package com.skeleton.feed.dto;
 
-import com.skeleton.feed.enums.Order;
+import com.skeleton.feed.enums.Direction;
 import com.skeleton.feed.enums.OrderBy;
 import com.skeleton.feed.enums.SearchBy;
 import com.skeleton.feed.enums.SnsType;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class PostQueryRequest {
     private String hashtag;
 
@@ -14,7 +16,7 @@ public class PostQueryRequest {
 
     private OrderBy orderBy = OrderBy.CREATED_AT;
 
-    private Order order = Order.DESC;
+    private Direction direction = Direction.DESC;
 
     private SearchBy searchBy = SearchBy.TITLE_CONTENT;
 

--- a/src/main/java/com/skeleton/feed/dto/PostResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/PostResponse.java
@@ -1,0 +1,41 @@
+package com.skeleton.feed.dto;
+
+import com.skeleton.feed.entity.Hashtag;
+import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.entity.PostHashtag;
+import com.skeleton.feed.enums.SnsType;
+import lombok.Builder;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+public class PostResponse {
+    private Long id;
+    private String contentId;
+    private SnsType type;
+    private String title;
+    private String content;
+    private Set<String> hashtags;
+    private int viewCount;
+    private int likeCount;
+    private int shareCount;
+
+    public static PostResponse fromEntity(Post post, String limitedContent) {
+        return PostResponse.builder()
+                .id(post.getId())
+                .contentId(post.getContentId())
+                .type(post.getType())
+                .title(post.getTitle())
+                .content(limitedContent)
+                .viewCount(post.getViewCount())
+                .likeCount(post.getLikeCount())
+                .shareCount(post.getShareCount())
+                .hashtags(post.getPostHashtags()
+                        .stream()
+                        .map(PostHashtag::getHashtag)
+                        .map(Hashtag::getName)
+                        .collect(Collectors.toSet()))
+                .build();
+    }
+}

--- a/src/main/java/com/skeleton/feed/dto/PostResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/PostResponse.java
@@ -5,10 +5,12 @@ import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.entity.PostHashtag;
 import com.skeleton.feed.enums.SnsType;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Getter
 @Builder
 public class PostResponse {
     private Long id;

--- a/src/main/java/com/skeleton/feed/entity/Hashtag.java
+++ b/src/main/java/com/skeleton/feed/entity/Hashtag.java
@@ -1,5 +1,6 @@
 package com.skeleton.feed.entity;
 
+import com.skeleton.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.util.Set;
 @Getter
 @Table(name = "hashtag")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Hashtag {
+public class Hashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)

--- a/src/main/java/com/skeleton/feed/entity/PostHashtag.java
+++ b/src/main/java/com/skeleton/feed/entity/PostHashtag.java
@@ -1,5 +1,6 @@
 package com.skeleton.feed.entity;
 
+import com.skeleton.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "post_hashtag")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostHashtag {
+public class PostHashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)

--- a/src/main/java/com/skeleton/feed/enums/Direction.java
+++ b/src/main/java/com/skeleton/feed/enums/Direction.java
@@ -4,14 +4,13 @@ import com.skeleton.common.util.EnumMapperType;
 import lombok.Getter;
 
 @Getter
-public enum SearchBy implements EnumMapperType {
-    TITLE("title"),
-    CONTENT("content"),
-    TITLE_CONTENT("title,content");
+public enum Direction implements EnumMapperType {
+    ASC("asc"),
+    DESC("desc");
 
     private final String value;
 
-    SearchBy(String value) {
+    Direction(String value) {
         this.value = value;
     }
 }

--- a/src/main/java/com/skeleton/feed/enums/Order.java
+++ b/src/main/java/com/skeleton/feed/enums/Order.java
@@ -1,6 +1,0 @@
-package com.skeleton.feed.enums;
-
-public enum Order {
-    ASC,
-    DESC;
-}

--- a/src/main/java/com/skeleton/feed/enums/Order.java
+++ b/src/main/java/com/skeleton/feed/enums/Order.java
@@ -1,0 +1,6 @@
+package com.skeleton.feed.enums;
+
+public enum Order {
+    ASC,
+    DESC;
+}

--- a/src/main/java/com/skeleton/feed/enums/OrderBy.java
+++ b/src/main/java/com/skeleton/feed/enums/OrderBy.java
@@ -1,10 +1,20 @@
 package com.skeleton.feed.enums;
 
-public enum OrderBy {
-    CREATED_AT,
-    UPDATED_AT,
-    LIKE_COUNT,
-    SHARE_COUNT,
-    VIEW_COUNT;
+import com.skeleton.common.util.EnumMapperType;
+import lombok.Getter;
+
+@Getter
+public enum OrderBy implements EnumMapperType {
+    CREATED_AT("createdAt"),
+    UPDATED_AT("updatedAt"),
+    LIKE_COUNT("likeCount"),
+    SHARE_COUNT("shareCount"),
+    VIEW_COUNT("viewCount");
+
+    private final String value;
+
+    OrderBy(String value) {
+        this.value = value;
+    }
 }
 

--- a/src/main/java/com/skeleton/feed/enums/OrderBy.java
+++ b/src/main/java/com/skeleton/feed/enums/OrderBy.java
@@ -1,0 +1,10 @@
+package com.skeleton.feed.enums;
+
+public enum OrderBy {
+    CREATED_AT,
+    UPDATED_AT,
+    LIKE_COUNT,
+    SHARE_COUNT,
+    VIEW_COUNT;
+}
+

--- a/src/main/java/com/skeleton/feed/enums/SearchBy.java
+++ b/src/main/java/com/skeleton/feed/enums/SearchBy.java
@@ -1,0 +1,7 @@
+package com.skeleton.feed.enums;
+
+public enum SearchBy {
+    TITLE,
+    CONTENT,
+    TITLE_CONTENT;
+}

--- a/src/main/java/com/skeleton/feed/enums/SnsType.java
+++ b/src/main/java/com/skeleton/feed/enums/SnsType.java
@@ -1,8 +1,18 @@
 package com.skeleton.feed.enums;
 
-public enum SnsType {
-    FACEBOOK,
-    TWITTER,
-    INSTAGRAM,
-    THREADS
+import com.skeleton.common.util.EnumMapperType;
+import lombok.Getter;
+
+@Getter
+public enum SnsType implements EnumMapperType {
+    FACEBOOK("facebook"),
+    TWITTER("twitter"),
+    INSTAGRAM("instagram"),
+    THREADS("threads");
+
+    private final String value;
+
+    SnsType(String value) {
+        this.value = value;
+    }
 }

--- a/src/main/java/com/skeleton/feed/repository/PostRepository.java
+++ b/src/main/java/com/skeleton/feed/repository/PostRepository.java
@@ -5,10 +5,24 @@ import com.skeleton.feed.enums.SnsType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Page<Post> findByHashtagAndTypeAndTitleContainingOrContentContaining(
-            String hashtag, SnsType type, String title, String content, Pageable pageable);
+    @Query("SELECT p FROM Post p " +
+            "INNER JOIN p.postHashtags ph " +
+            "INNER JOIN ph.hashtag h " +
+            "WHERE (h.name = :hashtag OR :hashtag IS NULL) " +
+            "AND (p.type = :type OR :type IS NULL) " +
+            "AND (p.title LIKE %:title% OR :title IS NULL) " +
+            "AND (p.content LIKE %:content% OR :content IS NULL)")
+    Page<Post> findPostsByConditions(
+            @Param("hashtag") String hashtag,
+            @Param("type") SnsType type,
+            @Param("title") String title,
+            @Param("content") String content,
+            Pageable pageable);
 }
+

--- a/src/main/java/com/skeleton/feed/repository/PostRepository.java
+++ b/src/main/java/com/skeleton/feed/repository/PostRepository.java
@@ -14,15 +14,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p " +
             "INNER JOIN p.postHashtags ph " +
             "INNER JOIN ph.hashtag h " +
-            "WHERE (h.name = :hashtag OR :hashtag IS NULL) " +
-            "AND (p.type = :type OR :type IS NULL) " +
-            "AND (p.title LIKE %:title% OR :title IS NULL) " +
-            "AND (p.content LIKE %:content% OR :content IS NULL)")
+            "WHERE (h.name = :hashtag) " +
+            "AND (:type IS NULL OR p.type = :type) " +
+            "AND ((:keyword IS NULL) " +
+            "OR (:searchInTitle = true AND p.title LIKE %:keyword%) " +
+            "OR (:searchInContent = true AND p.content LIKE %:keyword%))")
     Page<Post> findPostsByConditions(
             @Param("hashtag") String hashtag,
             @Param("type") SnsType type,
-            @Param("title") String title,
-            @Param("content") String content,
+            @Param("keyword") String keyword,
+            @Param("searchInTitle") boolean searchInTitle,
+            @Param("searchInContent") boolean searchInContent,
             Pageable pageable);
 }
 

--- a/src/main/java/com/skeleton/feed/repository/PostRepository.java
+++ b/src/main/java/com/skeleton/feed/repository/PostRepository.java
@@ -1,9 +1,14 @@
 package com.skeleton.feed.repository;
 
 import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.enums.SnsType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findByHashtagAndTypeAndTitleContainingOrContentContaining(
+            String hashtag, SnsType type, String title, String content, Pageable pageable);
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -1,11 +1,60 @@
 package com.skeleton.feed.service;
 
+import com.skeleton.feed.dto.PostQueryRequest;
+import com.skeleton.feed.dto.PostResponse;
+import com.skeleton.feed.enums.SearchBy;
 import com.skeleton.feed.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+
+    public Page<PostResponse> getPostsByQuery(PostQueryRequest request, User user) {
+        String hashtag = getHashtag(request, user);
+        Pageable pageable = getPageable(request);
+        String[] searchKeyword = getSearchKeyword(request);
+
+        return postRepository.findByHashtagAndTypeAndTitleContainingOrContentContaining(
+                        hashtag, request.getType(), searchKeyword[0], searchKeyword[1], pageable)
+                .map(post -> PostResponse.fromEntity(post, limitContent(post.getContent())));
+    }
+
+    private String getHashtag(PostQueryRequest request, User user) {
+        return StringUtils.hasText(request.getHashtag()) ? request.getHashtag() : user.getUsername();
+    }
+
+    private Pageable getPageable(PostQueryRequest request) {
+        return PageRequest.of(request.getPage(), request.getPageCount(),
+                Sort.by(request.getOrder().name(), request.getOrderBy().name()));
+    }
+
+    private String[] getSearchKeyword(PostQueryRequest request) {
+        String title = null;
+        String content = null;
+
+        if (StringUtils.hasText(request.getSearch())) {
+            if (request.getSearchBy() == SearchBy.TITLE_CONTENT) {
+                title = request.getSearch();
+                content = request.getSearch();
+            } else if (request.getSearchBy() == SearchBy.TITLE) {
+                title = request.getSearch();
+            } else if (request.getSearchBy() == SearchBy.CONTENT) {
+                content = request.getSearch();
+            }
+        }
+
+        return new String[] { title, content };
+    }
+
+    private String limitContent(String content) {
+        return content.substring(0, Math.min(content.length(), 20));
+    }
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -1,21 +1,21 @@
 package com.skeleton.feed.service;
 
-import com.skeleton.feed.dto.PostQueryRequest;
-import com.skeleton.feed.dto.PostResponse;
-import com.skeleton.feed.enums.Direction;
-import com.skeleton.feed.enums.SearchBy;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
 import com.skeleton.feed.dto.AddShareResponse;
+import com.skeleton.feed.dto.PostQueryRequest;
+import com.skeleton.feed.dto.PostResponse;
 import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.enums.Direction;
+import com.skeleton.feed.enums.SearchBy;
 import com.skeleton.feed.repository.PostRepository;
-import com.skeleton.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -26,8 +26,8 @@ public class PostService {
     private final PostRepository postRepository;
 
     @Transactional(readOnly = true)
-    public Page<PostResponse> getPostsByQuery(PostQueryRequest request, User user) {
-        String hashtag = getHashtag(request, user);
+    public Page<PostResponse> getPostsByQuery(PostQueryRequest request, Authentication authentication) {
+        String hashtag = getHashtag(request, authentication);
         Pageable pageable = getPageable(request);
         String[] searchKeyword = getSearchKeyword(request);
 
@@ -36,8 +36,9 @@ public class PostService {
                 .map(post -> PostResponse.fromEntity(post, limitContent(post.getContent())));
     }
 
-    private String getHashtag(PostQueryRequest request, User user) {
-        return StringUtils.hasText(request.getHashtag()) ? request.getHashtag() : user.getAccount();
+    private String getHashtag(PostQueryRequest request, Authentication authentication) {
+        String userAccount = authentication.getPrincipal().toString();
+        return StringUtils.hasText(request.getHashtag()) ? request.getHashtag() : userAccount;
     }
 
     private Pageable getPageable(PostQueryRequest request) {

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -2,6 +2,7 @@ package com.skeleton.feed.service;
 
 import com.skeleton.feed.dto.PostQueryRequest;
 import com.skeleton.feed.dto.PostResponse;
+import com.skeleton.feed.enums.Direction;
 import com.skeleton.feed.enums.SearchBy;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
@@ -30,8 +31,8 @@ public class PostService {
         Pageable pageable = getPageable(request);
         String[] searchKeyword = getSearchKeyword(request);
 
-        return postRepository.findByHashtagAndTypeAndTitleContainingOrContentContaining(
-                        hashtag, request.getType(), searchKeyword[0], searchKeyword[1], pageable)
+        return postRepository.findPostsByConditions(
+                hashtag, request.getType(), searchKeyword[0], searchKeyword[1], pageable)
                 .map(post -> PostResponse.fromEntity(post, limitContent(post.getContent())));
     }
 
@@ -40,8 +41,9 @@ public class PostService {
     }
 
     private Pageable getPageable(PostQueryRequest request) {
-        return PageRequest.of(request.getPage(), request.getPageCount(),
-                Sort.by(request.getOrder().name(), request.getOrderBy().name()));
+        String orderBy = request.getOrderBy().getValue();
+        Sort.Direction direction = (request.getDirection() == Direction.DESC)? Sort.Direction.DESC : Sort.Direction.ASC;
+        return PageRequest.of(request.getPage(), request.getPageCount(), Sort.by(direction, orderBy));
     }
 
     private String[] getSearchKeyword(PostQueryRequest request) {

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -9,6 +9,7 @@ import com.skeleton.feed.dto.AddLikeResponse;
 import com.skeleton.feed.dto.AddShareResponse;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
+import com.skeleton.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,12 +17,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
 
+    @Transactional(readOnly = true)
     public Page<PostResponse> getPostsByQuery(PostQueryRequest request, User user) {
         String hashtag = getHashtag(request, user);
         Pageable pageable = getPageable(request);
@@ -33,7 +36,7 @@ public class PostService {
     }
 
     private String getHashtag(PostQueryRequest request, User user) {
-        return StringUtils.hasText(request.getHashtag()) ? request.getHashtag() : user.getUsername();
+        return StringUtils.hasText(request.getHashtag()) ? request.getHashtag() : user.getAccount();
     }
 
     private Pageable getPageable(PostQueryRequest request) {

--- a/src/main/java/com/skeleton/user/entity/User.java
+++ b/src/main/java/com/skeleton/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.skeleton.user.entity;
 
+import com.skeleton.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,16 +11,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "users")
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String account;
 
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
     @Builder


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

조건에 부합하는 게시물 목록을 조회하는 API를 구현했습니다. 
`EnumConverterFactory`를 사용하여 쿼리 파라미터가 카멜 케이스로 전달되더라도  Enum 형식으로 변환할 수 있습니다.

## 📋 변경 사항

- [x] 새로운 기능 추가


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

Issue #9 

## 📑 참고  자료
`ConverterFactory` 사용 방법에 대한 참고 자료입니다.
* [블로그 1](https://wildeveloperetrain.tistory.com/189)
* [블로그 2](https://wannaqueen.gitbook.io/spring5/spring-5.0/3.-by-ys-sh/3.4-by-sh/3.4.2-by-sh)

## 🙌 리뷰 및 피드백

`PostRepository`의 `findPostsByConditions` 쿼리 메서드에서 `@Query` 어노테이션을 사용해 직접 쿼리를 작성해보았습니다.
개발하면서 가장 어려웠던 부분인데, 개선할 점에 대해 피드백 주시면 감사하겠습니다!
