### PR TITLE
feat: 게시물 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -26,7 +26,7 @@ public class PostController {
         return ResponseEntity.ok().body(postService.addLike(id));
     }
 
-    @GetMapping("{id}")
+    @GetMapping("/{id}")
     private ResponseEntity<?> getPost(@PathVariable Long id) {
         return ResponseEntity.ok().body(postService.getPostDetail(id));
     }

--- a/src/main/java/com/skeleton/feed/controller/PostController.java
+++ b/src/main/java/com/skeleton/feed/controller/PostController.java
@@ -15,4 +15,8 @@ public class PostController {
     private ResponseEntity<?> addLike(@PathVariable Long id) {
         return ResponseEntity.ok().body(postService.addLike(id));
     }
+    @GetMapping("{id}")
+    private ResponseEntity<?> getPost(@PathVariable Long id) {
+        return ResponseEntity.ok().body(postService.getPostDetail(id));
+    }
 }

--- a/src/main/java/com/skeleton/feed/dto/PostDetailResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/PostDetailResponse.java
@@ -1,12 +1,11 @@
 package com.skeleton.feed.dto;
 
-import com.skeleton.feed.entity.Hashtag;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.enums.SnsType;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record PostResponse(
+public record PostDetailResponse(
         String contentId,
         SnsType type,
         String title,
@@ -18,7 +17,7 @@ public record PostResponse(
         LocalDateTime createdAt,
         LocalDateTime updatedAt) {
 
-    public PostResponse(Post post) {
+    public PostDetailResponse(Post post) {
         this(
                 post.getContentId(),
                 post.getType(),

--- a/src/main/java/com/skeleton/feed/dto/PostResponse.java
+++ b/src/main/java/com/skeleton/feed/dto/PostResponse.java
@@ -1,0 +1,35 @@
+package com.skeleton.feed.dto;
+
+import com.skeleton.feed.entity.Hashtag;
+import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.enums.SnsType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostResponse(
+        String contentId,
+        SnsType type,
+        String title,
+        String content,
+        List<String> hashtags,
+        int viewCount,
+        int likeCount,
+        int shareCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+
+    public PostResponse(Post post) {
+        this(
+                post.getContentId(),
+                post.getType(),
+                post.getTitle(),
+                post.getContent(),
+                post.getHashtagsAsStringList(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getShareCount(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/skeleton/feed/entity/Post.java
+++ b/src/main/java/com/skeleton/feed/entity/Post.java
@@ -3,6 +3,7 @@ package com.skeleton.feed.entity;
 import com.skeleton.common.entity.BaseTimeEntity;
 import com.skeleton.feed.enums.SnsType;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,5 +46,14 @@ public class Post extends BaseTimeEntity {
     // == 비즈니스 로직 == //
     public void addlike(){
         this.likeCount +=1;
+    }
+    public void addView() {
+        this.viewCount += 1;
+    }
+
+    public List<String> getHashtagsAsStringList() {
+        return postHashtags.stream()
+                .map(postHashtag -> postHashtag.getHashtag().getName())
+                .toList();
     }
 }

--- a/src/main/java/com/skeleton/feed/service/CountService.java
+++ b/src/main/java/com/skeleton/feed/service/CountService.java
@@ -1,0 +1,22 @@
+package com.skeleton.feed.service;
+
+import com.skeleton.common.exception.CustomException;
+import com.skeleton.common.exception.ErrorCode;
+import com.skeleton.feed.entity.Post;
+import com.skeleton.feed.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CountService {
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void incrementViewCount(Long id) {
+        Post post = postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        post.addView();
+        postRepository.save(post);
+    }
+}

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -3,6 +3,7 @@ package com.skeleton.feed.service;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
+import com.skeleton.feed.dto.PostResponse;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,22 @@ public class PostService {
         //snsApiCallerService.clickLikeOnSns(post.getContentId(), post.getType());
         post.addlike();
         return new AddLikeResponse(post);
+    }
+
+    public PostResponse getPostDetail(Long id) {
+        Post post = getPost(id);
+        incrementViewCount(id);
+        return new PostResponse(post);
+    }
+
+    public Post getPost(Long id) {
+        return postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    @Transactional
+    public void incrementViewCount(Long postId) {
+        Post post = getPost(postId);
+        post.addView();
+        postRepository.save(post);
     }
 }

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -3,7 +3,7 @@ package com.skeleton.feed.service;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
-import com.skeleton.feed.dto.PostResponse;
+import com.skeleton.feed.dto.PostDetailResponse;
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +26,10 @@ public class PostService {
         return new AddLikeResponse(post);
     }
 
-    public PostResponse getPostDetail(Long id) {
+    public PostDetailResponse getPostDetail(Long id) {
         Post post = getPost(id);
         incrementViewCount(id);
-        return new PostResponse(post);
+        return new PostDetailResponse(post);
     }
 
     public Post getPost(Long id) {

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -77,7 +77,6 @@ public class PostService {
         return new AddLikeResponse(post);
     }
 
-
     public PostDetailResponse getPostDetail(Long id) {
         Post post = getPost(id);
         incrementViewCount(id);

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -3,13 +3,10 @@ package com.skeleton.feed.service;
 import com.skeleton.common.exception.CustomException;
 import com.skeleton.common.exception.ErrorCode;
 import com.skeleton.feed.dto.AddLikeResponse;
-
 import com.skeleton.feed.dto.PostDetailResponse;
-
 import com.skeleton.feed.dto.AddShareResponse;
 import com.skeleton.feed.dto.PostQueryRequest;
 import com.skeleton.feed.dto.PostResponse;
-
 import com.skeleton.feed.entity.Post;
 import com.skeleton.feed.enums.Direction;
 import com.skeleton.feed.enums.SearchBy;
@@ -28,6 +25,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final CountService countService;
 
     @Transactional(readOnly = true)
     public Page<PostResponse> getPostsByQuery(PostQueryRequest request, Authentication authentication) {
@@ -76,21 +74,15 @@ public class PostService {
         post.addLike();
         return new AddLikeResponse(post);
     }
-    @Transactional
+    @Transactional(readOnly = true)
     public PostDetailResponse getPostDetail(Long id) {
         Post post = getPost(id);
-        incrementViewCount(id);
+        countService.incrementViewCount(id);
         return new PostDetailResponse(post);
     }
 
     private Post getPost(Long id) {
         return postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-    }
-
-    private void incrementViewCount(Long postId) {
-        Post post = getPost(postId);
-        post.addView();
-        postRepository.save(post);
     }
 
     @Transactional

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -83,11 +83,11 @@ public class PostService {
         return new PostDetailResponse(post);
     }
 
-    public Post getPost(Long id) {
+    private Post getPost(Long id) {
         return postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
     }
 
-    public void incrementViewCount(Long postId) {
+    private void incrementViewCount(Long postId) {
         Post post = getPost(postId);
         post.addView();
         postRepository.save(post);

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -76,7 +76,7 @@ public class PostService {
         post.addLike();
         return new AddLikeResponse(post);
     }
-    @Transactional(readOnly = true)
+    @Transactional
     public PostDetailResponse getPostDetail(Long id) {
         Post post = getPost(id);
         incrementViewCount(id);

--- a/src/main/java/com/skeleton/feed/service/PostService.java
+++ b/src/main/java/com/skeleton/feed/service/PostService.java
@@ -76,7 +76,7 @@ public class PostService {
         post.addLike();
         return new AddLikeResponse(post);
     }
-
+    @Transactional(readOnly = true)
     public PostDetailResponse getPostDetail(Long id) {
         Post post = getPost(id);
         incrementViewCount(id);
@@ -87,7 +87,6 @@ public class PostService {
         return postRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
     }
 
-    @Transactional
     public void incrementViewCount(Long postId) {
         Post post = getPost(postId);
         post.addView();


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약
- 게시물의 상세 조회 API를 구현했습니다 
- 요구사항에 따라 API를 호출 할 때마다 조회수를 증가하는 기능을 추가했습니다

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📌 체크리스트

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#38
